### PR TITLE
Remove unnecessary image tag on NWS:LTTR page

### DIFF
--- a/assets/javascripts/discourse/templates/newsletter.hbs
+++ b/assets/javascripts/discourse/templates/newsletter.hbs
@@ -19,9 +19,7 @@
   </div>
 
   <div class="grid">
-    <div class="grid__item col-1-2 portable--col-1-1 newsletter-preview p">
-      <img src="nwslttr_landing-preview.png" alt="" />
-    </div>
+    <div class="grid__item col-1-2 portable--col-1-1 newsletter-preview p"></div>
     <div class="grid__item col-1-2 portable--col-1-1 pr++">
       <h3 class="mb-">Latest Vulnerabilities</h3>
       <p class="mb">


### PR DESCRIPTION
Closes: https://sourceclear.atlassian.net/browse/FLAT-416.
